### PR TITLE
Added ethtool show driver version

### DIFF
--- a/SOURCES/0010-Show-Version.patch
+++ b/SOURCES/0010-Show-Version.patch
@@ -1,0 +1,64 @@
+
+##########
+## NOTE ##
+##########
+## This depends on RPM build adding DRV_VERSION to e1000.h
+##
+## Must be included in spec file:
+##   /usr/bin/echo '#define DRV_VERSION "%{version}"' >> src/e1000.h
+##
+
+--- a/src/e1000.h	2025-02-10 21:44:29.686651623 +0000
++++ b/src/e1000.h	2025-02-10 21:44:47.630509849 +0000
+@@ -462,6 +462,7 @@
+ };
+ 
+ extern char e1000e_driver_name[];
++extern const char e1000e_driver_version[];
+ 
+ void e1000e_check_options(struct e1000_adapter *adapter);
+ void e1000e_set_ethtool_ops(struct net_device *netdev);
+--- a/src/netdev.c	2025-02-01 17:22:34.000000000 +0000
++++ b/src/netdev.c	2025-02-10 21:44:13.514779395 +0000
+@@ -29,7 +29,11 @@
+ 
+ #include "e1000.h"
+ 
++
++/* DRV_VERSION is added to e1000.h by RPM build from spec file */
++
+ char e1000e_driver_name[] = "e1000e";
++const char e1000e_driver_version[] = DRV_VERSION;
+ 
+ #define DEFAULT_MSG_ENABLE (NETIF_MSG_DRV|NETIF_MSG_PROBE|NETIF_MSG_LINK)
+ static int debug = -1;
+@@ -7892,7 +7894,8 @@
+  **/
+ static int __init e1000_init_module(void)
+ {
+-	pr_info("Intel(R) PRO/1000 Network Driver\n");
++	pr_info("Intel(R) PRO/1000 Network Driver - %s\n",
++		e1000e_driver_version);
+ 	pr_info("Copyright(c) 1999 - 2015 Intel Corporation.\n");
+ 
+ 	return pci_register_driver(&e1000_driver);
+--- a/src/ethtool.c	2025-02-10 22:54:56.357243978 +0000
++++ b/src/ethtool.c	2025-02-10 22:56:41.844412135 +0000
+@@ -640,6 +640,8 @@
+ 	struct e1000_adapter *adapter = netdev_priv(netdev);
+ 
+ 	strlcpy(drvinfo->driver, e1000e_driver_name, sizeof(drvinfo->driver));
++	strlcpy(drvinfo->version, e1000e_driver_version,
++		sizeof(drvinfo->version));
+ 
+ 	/* EEPROM image version # is reported as firmware version # for
+ 	 * PCI-E controllers
+--- a/src/netdev.c	2025-02-10 23:19:32.317161356 +0000
++++ b/src/netdev.c	2025-02-10 23:25:36.458229910 +0000
+@@ -7910,5 +7910,6 @@
+ MODULE_AUTHOR("Intel Corporation, <linux.nics@intel.com>");
+ MODULE_DESCRIPTION("Intel(R) PRO/1000 Network Driver");
+ MODULE_LICENSE("GPL v2");
++MODULE_VERSION(DRV_VERSION);
+ 
+ /* netdev.c */

--- a/SPECS/intel-e1000e.spec
+++ b/SPECS/intel-e1000e.spec
@@ -82,7 +82,7 @@ find %{buildroot}/lib/modules/%{kernel_version} -name "*.ko" -type f | xargs chm
 %{?_cov_results_package}
 
 %changelog
-* Tue May 19 2025 Andrew Lindh <andrew@netplex.net> - 5.10.179-2
+* Mon May 19 2025 Andrew Lindh <andrew@netplex.net> - 5.10.179-2
 - Add show version for ethtool
 
 * Tue May 06 2025 Thierry Escande <thierry.escande@vates.tech> - 5.10.179-1

--- a/SPECS/intel-e1000e.spec
+++ b/SPECS/intel-e1000e.spec
@@ -16,7 +16,7 @@
 Summary: %{vendor_name} %{driver_name} device drivers
 Name: %{vendor_label}-%{driver_name}
 Version: 5.10.179
-Release: 1%{?dist}
+Release: 2%{?dist}
 License: GPL
 # Sources from drivers/net/ethernet/intel/e1000e of Linux kernel v5.10.179, last
 # release with patches for the e1000e driver in the 5.10.y branch
@@ -33,6 +33,7 @@ Patch1005: 0006-Revert-PM-sleep-core-Rename-DPM_FLAG_NEVER_SKIP.patch
 Patch1006: 0007-Add-missing-define-for-falltrough.patch
 Patch1007: 0008-Remove-txqueue-parameter-for-ndo_tx_timeout.patch
 Patch1008: 0009-Add-missing-include-for-PCIE_LINK_STATE_L0S-1-define.patch
+Patch1009: 0010-Show-Version.patch
 
 BuildRequires: gcc
 BuildRequires: kernel-devel
@@ -51,7 +52,7 @@ version %{kernel_version}.
 %{?_cov_prepare}
 
 # Set module version to upstream kernel release
-/usr/bin/echo 'MODULE_VERSION("%{version}");' >> src/netdev.c
+/usr/bin/echo '#define DRV_VERSION "%{version}"' >> src/e1000.h
 
 %build
 %{?_cov_wrap} %{make_build} -C /lib/modules/%{kernel_version}/build M=$(pwd)/src KSRC=/lib/modules/%{kernel_version}/build modules
@@ -81,6 +82,9 @@ find %{buildroot}/lib/modules/%{kernel_version} -name "*.ko" -type f | xargs chm
 %{?_cov_results_package}
 
 %changelog
+* Tue May 19 2025 Andrew Lindh <andrew@netplex.net> - 5.10.179-2
+- Add show version for ethtool
+
 * Tue May 06 2025 Thierry Escande <thierry.escande@vates.tech> - 5.10.179-1
 - Import sources from upstream kernel v5.10.179
 - Set module version to upstream kernel release


### PR DESCRIPTION
Now shows:
```
# ethtool -i eth0
driver: e1000e
version: 5.10.179
firmware-version: 0.1-4
expansion-rom-version:
bus-info: 0000:00:1f.6
supports-statistics: yes
supports-test: yes
supports-eeprom-access: yes
supports-register-dump: yes
supports-priv-flags: yes
```

This is a dynamic update and the version is added to the code by the rpmbuild command based on spec file.
