### PR TITLE
Fix module version reported by modinfo and ethtool

### DIFF
--- a/SOURCES/0001-Add-support-to-set-module-version.patch
+++ b/SOURCES/0001-Add-support-to-set-module-version.patch
@@ -1,0 +1,68 @@
+From bcb70e9c7eb8ffb5ca5302a0b289af270b89cdd7 Mon Sep 17 00:00:00 2001
+From: Thierry Escande <thierry.escande@vates.tech>
+Date: Tue, 20 May 2025 10:59:17 +0200
+Subject: [PATCH] Add support to set module version
+Content-Type: text/plain; charset = "utf-8"
+Content-Transfert-Encoding: 8bit
+
+This patch adds the DRV_VERSION macro used to report the module version
+by both modinfo and ethtool.
+
+The macro has to be set to the correct version from the specfile using
+sed.
+
+Based on patch from Andrew Lindh <andrew@netplex.net>
+
+Signed-off-by: Thierry Escande <thierry.escande@vates.tech>
+---
+ src/e1000.h   | 2 ++
+ src/ethtool.c | 1 +
+ src/netdev.c  | 4 +++-
+ 3 files changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/src/e1000.h b/src/e1000.h
+index bf8506a..cd87181 100644
+--- a/src/e1000.h
++++ b/src/e1000.h
+@@ -587,4 +587,6 @@ void __ew32(struct e1000_hw *hw, unsigned long reg, u32 val);
+ #define E1000_READ_REG_ARRAY(a, reg, offset) \
+ 	(readl((a)->hw_addr + reg + ((offset) << 2)))
+ 
++#define DRV_VERSION "@@DRV_VERSION@@"
++
+ #endif /* _E1000_H_ */
+diff --git a/src/ethtool.c b/src/ethtool.c
+index c48ddaf..81d2a88 100644
+--- a/src/ethtool.c
++++ b/src/ethtool.c
+@@ -640,6 +640,7 @@ static void e1000_get_drvinfo(struct net_device *netdev,
+ 	struct e1000_adapter *adapter = netdev_priv(netdev);
+ 
+ 	strlcpy(drvinfo->driver, e1000e_driver_name, sizeof(drvinfo->driver));
++	strlcpy(drvinfo->version, DRV_VERSION, sizeof(drvinfo->version));
+ 
+ 	/* EEPROM image version # is reported as firmware version # for
+ 	 * PCI-E controllers
+diff --git a/src/netdev.c b/src/netdev.c
+index af2e2f8..d1b9028 100644
+--- a/src/netdev.c
++++ b/src/netdev.c
+@@ -7874,7 +7874,7 @@ static struct pci_driver e1000_driver = {
+  **/
+ static int __init e1000_init_module(void)
+ {
+-	pr_info("Intel(R) PRO/1000 Network Driver\n");
++	pr_info("Intel(R) PRO/1000 Network Driver - %s\n", DRV_VERSION);
+ 	pr_info("Copyright(c) 1999 - 2015 Intel Corporation.\n");
+ 
+ 	return pci_register_driver(&e1000_driver);
+@@ -7897,4 +7897,6 @@ MODULE_AUTHOR("Intel Corporation, <linux.nics@intel.com>");
+ MODULE_DESCRIPTION("Intel(R) PRO/1000 Network Driver");
+ MODULE_LICENSE("GPL v2");
+ 
++MODULE_VERSION(DRV_VERSION);
++
+ /* netdev.c */
+-- 
+2.47.2
+

--- a/SPECS/intel-e1000e.spec
+++ b/SPECS/intel-e1000e.spec
@@ -16,7 +16,7 @@
 Summary: %{vendor_name} %{driver_name} device drivers
 Name: %{vendor_label}-%{driver_name}
 Version: 5.10.179
-Release: 1%{?dist}
+Release: 2%{?dist}
 License: GPL
 # Sources from drivers/net/ethernet/intel/e1000e of Linux kernel v5.10.179, last
 # release with patches for the e1000e driver in the 5.10.y branch
@@ -33,6 +33,7 @@ Patch1005: 0006-Revert-PM-sleep-core-Rename-DPM_FLAG_NEVER_SKIP.patch
 Patch1006: 0007-Add-missing-define-for-falltrough.patch
 Patch1007: 0008-Remove-txqueue-parameter-for-ndo_tx_timeout.patch
 Patch1008: 0009-Add-missing-include-for-PCIE_LINK_STATE_L0S-1-define.patch
+Patch1009: 0001-Add-support-to-set-module-version.patch
 
 BuildRequires: gcc
 BuildRequires: kernel-devel
@@ -51,7 +52,7 @@ version %{kernel_version}.
 %{?_cov_prepare}
 
 # Set module version to upstream kernel release
-/usr/bin/echo 'MODULE_VERSION("%{version}");' >> src/netdev.c
+sed -e 's|@@DRV_VERSION@@|%{version}|' -i src/e1000.h
 
 %build
 %{?_cov_wrap} %{make_build} -C /lib/modules/%{kernel_version}/build M=$(pwd)/src KSRC=/lib/modules/%{kernel_version}/build modules
@@ -81,6 +82,9 @@ find %{buildroot}/lib/modules/%{kernel_version} -name "*.ko" -type f | xargs chm
 %{?_cov_results_package}
 
 %changelog
+* Tue May 20 2025 Thierry Escande <thierry.escande@vates.tech> - 5.10.179-2
+- Fix module version reported by modinfo and ethtool
+
 * Tue May 06 2025 Thierry Escande <thierry.escande@vates.tech> - 5.10.179-1
 - Import sources from upstream kernel v5.10.179
 - Set module version to upstream kernel release


### PR DESCRIPTION
This change adds a patch to set MODULE_VERSION and driver version reported by ethtool. It also adds the version to the init kernel message.

The DRV_VERSION macro is added to e1000.h header file and the correct version is set from the specfile using sed.